### PR TITLE
fix: remove get_module

### DIFF
--- a/move-vm/integration-tests/src/tests/cache_tests.rs
+++ b/move-vm/integration-tests/src/tests/cache_tests.rs
@@ -217,6 +217,7 @@ fn test_small_cache_update_module() {
 fn test_update_function(update_path: &str, cache_size: usize) -> VMResult<SerializedReturnValues> {
     let config = VMConfig {
         module_cache_capacity: cache_size,
+        allow_arbitrary: true,
         ..Default::default()
     };
 
@@ -306,7 +307,7 @@ fn test_deleted_function_update_module() {
     )
     .unwrap_err();
 
-    assert_eq!(err.major_status(), StatusCode::UNEXPECTED_VERIFIER_ERROR);
+    assert_eq!(err.major_status(), StatusCode::TYPE_RESOLUTION_FAILURE);
 }
 
 #[test]
@@ -317,7 +318,7 @@ fn test_private_function_update_module() {
     )
     .unwrap_err();
 
-    assert_eq!(err.major_status(), StatusCode::UNEXPECTED_VERIFIER_ERROR);
+    assert_eq!(err.major_status(), StatusCode::TYPE_RESOLUTION_FAILURE);
 }
 
 fn test_new_loader_after_update_function(

--- a/move-vm/runtime/src/config.rs
+++ b/move-vm/runtime/src/config.rs
@@ -29,6 +29,7 @@ pub struct VMConfig {
     pub aggregator_v2_type_tagging: bool,
     pub module_cache_capacity: usize,
     pub script_cache_capacity: usize,
+    pub allow_arbitrary: bool,
 }
 
 impl Default for VMConfig {
@@ -46,6 +47,7 @@ impl Default for VMConfig {
             aggregator_v2_type_tagging: false,
             module_cache_capacity: 1000,
             script_cache_capacity: 100,
+            allow_arbitrary: false,
         }
     }
 }

--- a/move-vm/runtime/src/data_cache.rs
+++ b/move-vm/runtime/src/data_cache.rs
@@ -11,7 +11,6 @@ use move_core_types::{
     gas_algebra::NumBytes,
     identifier::Identifier,
     language_storage::{ModuleId, TypeTag},
-    metadata::Metadata,
     resolver::MoveResolver,
     value::MoveTypeLayout,
     vm_status::StatusCode,
@@ -190,11 +189,8 @@ impl<'r> TransactionDataCache<'r> {
             let (ty_layout, has_aggregator_lifting) =
                 loader.type_to_type_layout_with_identifier_mappings(ty, checksum_store)?;
 
-            let module = loader.get_module(&ty_tag.module_id(), checksum_store)?;
-            let metadata: &[Metadata] = match &module {
-                Some(module) => &module.compiled_module().metadata,
-                None => &[],
-            };
+            let module = loader.load_module(&ty_tag.module_id(), checksum_store).map_err(|e| e.to_partial())?;
+            let metadata = &module.compiled_module().metadata;
 
             // If we need to process aggregator lifting, we pass type layout to remote.
             // Remote, in turn ensures that all aggregator values are lifted if the resolved

--- a/move-vm/runtime/src/data_cache.rs
+++ b/move-vm/runtime/src/data_cache.rs
@@ -189,7 +189,9 @@ impl<'r> TransactionDataCache<'r> {
             let (ty_layout, has_aggregator_lifting) =
                 loader.type_to_type_layout_with_identifier_mappings(ty, checksum_store)?;
 
-            let module = loader.load_module(&ty_tag.module_id(), checksum_store).map_err(|e| e.to_partial())?;
+            let module = loader
+                .load_module(&ty_tag.module_id(), checksum_store)
+                .map_err(|e| e.to_partial())?;
             let metadata = &module.compiled_module().metadata;
 
             // If we need to process aggregator lifting, we pass type layout to remote.

--- a/move-vm/runtime/src/loader/function.rs
+++ b/move-vm/runtime/src/loader/function.rs
@@ -159,8 +159,7 @@ impl Function {
         match &self.scope {
             Scope::Module(module_id) => {
                 let module = loader
-                    .get_module(module_id, cache_storage)
-                    .expect("ModuleId on Function must exist")
+                    .load_module(module_id, cache_storage)
                     .expect("ModuleId on Function must exist");
                 Resolver::for_module(loader, module)
             }

--- a/move-vm/runtime/src/loader/resolver.rs
+++ b/move-vm/runtime/src/loader/resolver.rs
@@ -65,11 +65,12 @@ impl<'a> Resolver<'a> {
         idx: FunctionHandleIndex,
         session_storage: &dyn SessionStorage,
     ) -> PartialVMResult<Arc<Function>> {
-        let idx = match &self.binary {
-            BinaryType::Module(module) => module.function_at(idx.0),
-            BinaryType::Script(script) => script.function_at(idx.0),
+        let (self_id, idx) = match &self.binary {
+            BinaryType::Module(module) => (Some(&module.id), module.function_at(idx.0)),
+            BinaryType::Script(script) => (None, script.function_at(idx.0)),
         };
-        self.loader.function_at(idx, session_storage)
+
+        self.loader.function_at(self_id, idx, session_storage)
     }
 
     pub(crate) fn function_from_instantiation(
@@ -77,11 +78,15 @@ impl<'a> Resolver<'a> {
         idx: FunctionInstantiationIndex,
         session_storage: &dyn SessionStorage,
     ) -> PartialVMResult<Arc<Function>> {
-        let func_inst = match &self.binary {
-            BinaryType::Module(module) => module.function_instantiation_at(idx.0),
-            BinaryType::Script(script) => script.function_instantiation_at(idx.0),
+        let (self_id, func_inst) = match &self.binary {
+            BinaryType::Module(module) => {
+                (Some(&module.id), module.function_instantiation_at(idx.0))
+            }
+            BinaryType::Script(script) => (None, script.function_instantiation_at(idx.0)),
         };
-        self.loader.function_at(&func_inst.handle, session_storage)
+
+        self.loader
+            .function_at(self_id, &func_inst.handle, session_storage)
     }
 
     pub(crate) fn instantiate_generic_function(

--- a/move-vm/runtime/src/runtime.rs
+++ b/move-vm/runtime/src/runtime.rs
@@ -641,7 +641,8 @@ impl VMRuntime {
     {
         Ok(self
             .loader
-            .get_module(module_id, session_cache)?
-            .and_then(|v| f(&v.compiled_module().metadata)))
+            .load_module(module_id, session_cache)
+            .map_err(|e| e.to_partial())
+            .map(|v| f(&v.compiled_module().metadata))?)
     }
 }

--- a/move-vm/runtime/src/runtime.rs
+++ b/move-vm/runtime/src/runtime.rs
@@ -639,10 +639,10 @@ impl VMRuntime {
     where
         F: FnOnce(&[Metadata]) -> Option<T>,
     {
-        Ok(self
+        self
             .loader
             .load_module(module_id, session_cache)
             .map_err(|e| e.to_partial())
-            .map(|v| f(&v.compiled_module().metadata))?)
+            .map(|v| f(&v.compiled_module().metadata))
     }
 }

--- a/move-vm/runtime/src/runtime.rs
+++ b/move-vm/runtime/src/runtime.rs
@@ -92,6 +92,14 @@ impl VMRuntime {
         _gas_meter: &mut impl GasMeter,
         compat: Compatibility,
     ) -> VMResult<()> {
+        // raise error when publish request with no check without allow_arbitrary 
+        // vm configuration.
+        if !self.loader.vm_config.allow_arbitrary && !compat.need_check_compat() {
+            return Err(PartialVMError::new(StatusCode::ABORTED)
+                .with_message("vm is not configured to allow arbitrary update".to_string())
+                .finish(Location::Undefined));
+        }
+
         // make checksum records for the publishing modules
         let mut checksums: HashMap<ModuleId, Checksum> = HashMap::new();
 

--- a/move-vm/runtime/src/session_cache.rs
+++ b/move-vm/runtime/src/session_cache.rs
@@ -100,14 +100,13 @@ impl<'r> SessionCache<'r> {
     pub(crate) fn record_publish(
         &mut self,
         module_id: &ModuleId,
-        module_blob: Bytes,
         checksum: Checksum,
+        module_size: usize,
+        arc_module: Arc<CompiledModule>,
     ) -> PartialVMResult<()> {
-        let module = self.deserialize_module(&module_blob)?;
-        let arc_module = Arc::new(module);
         self.modules
             .write()
-            .insert(module_id.clone(), (module_blob.len(), checksum, arc_module));
+            .insert(module_id.clone(), (module_size, checksum, arc_module));
         self.checksums.write().insert(module_id.clone(), checksum);
 
         Ok(())

--- a/move-vm/runtime/src/tracing.rs
+++ b/move-vm/runtime/src/tracing.rs
@@ -48,7 +48,7 @@ static DEBUGGING_ENABLED: Lazy<bool> =
 #[cfg(any(debug_assertions, feature = "debugging"))]
 pub static LOGGING_FILE_WRITER: Lazy<Mutex<std::io::BufWriter<File>>> = Lazy::new(|| {
     let file = OpenOptions::new()
-        .write(true)
+        
         .create(true)
         .append(true)
         .open(&*FILE_PATH)

--- a/move-vm/runtime/src/tracing.rs
+++ b/move-vm/runtime/src/tracing.rs
@@ -48,7 +48,6 @@ static DEBUGGING_ENABLED: Lazy<bool> =
 #[cfg(any(debug_assertions, feature = "debugging"))]
 pub static LOGGING_FILE_WRITER: Lazy<Mutex<std::io::BufWriter<File>>> = Lazy::new(|| {
     let file = OpenOptions::new()
-        
         .create(true)
         .append(true)
         .open(&*FILE_PATH)


### PR DESCRIPTION
Checksum based loader does not guarantee the existence of dependency modules. It should try reload even the called module is in cache.