### PR TITLE
fix: load module at cyclic check

### DIFF
--- a/move-vm/runtime/Cargo.toml
+++ b/move-vm/runtime/Cargo.toml
@@ -17,6 +17,7 @@ fail = "0.4.0"
 hashbrown = "0.14.3"
 lazy_static = "1.4.0"
 lru = "0.12.3"
+clru = "0.6.2"
 move-binary-format = { path = "../../move-binary-format" }
 once_cell = "1.7.2"
 parking_lot = "0.11.1"

--- a/move-vm/runtime/src/loader/cache.rs
+++ b/move-vm/runtime/src/loader/cache.rs
@@ -260,7 +260,7 @@ impl CacheHitRecords {
         self.checksums.get(checksum);
     }
 
-    pub(crate) fn peek(&self, checksum: &Checksum) -> bool {
-        self.checksums.peek(checksum).is_some()
+    pub(crate) fn contains(&self, checksum: &Checksum) -> bool {
+        self.checksums.contains(checksum)
     }
 }

--- a/move-vm/runtime/src/loader/loader_impl.rs
+++ b/move-vm/runtime/src/loader/loader_impl.rs
@@ -137,8 +137,8 @@ impl Loader {
                 )
                 .map_err(|e| e.finish(Location::Script))?;
 
-                // create cache hits entry
-                if !self.script_cache_hits.read().peek(&checksum) {
+                // create cache hits entry only if not exists.
+                if !self.script_cache_hits.read().contains(&checksum) {
                     let mut removed = self
                         .script_cache_hits
                         .write()
@@ -752,8 +752,8 @@ impl Loader {
 
         let checksum = module.checksum;
 
-        // create cache hits entry only if there is no cache hit entry.
-        if !self.module_cache_hits.read().peek(&checksum) {
+        // create cache hits entry only if not exists.
+        if !self.module_cache_hits.read().contains(&checksum) {
             let mut removed = self
                 .module_cache_hits
                 .write()
@@ -787,7 +787,7 @@ impl Loader {
         let module_cache_hits = self.module_cache_hits.read();
 
         for checksum in removed_modules.iter() {
-            if module_cache_hits.peek(checksum) {
+            if module_cache_hits.contains(checksum) {
                 continue;
             }
 
@@ -810,7 +810,7 @@ impl Loader {
         let script_cache_hits = self.script_cache_hits.read();
 
         for checksum in removed_scripts.iter() {
-            if script_cache_hits.peek(checksum) {
+            if script_cache_hits.contains(checksum) {
                 continue;
             }
 

--- a/move-vm/runtime/src/loader/loader_impl.rs
+++ b/move-vm/runtime/src/loader/loader_impl.rs
@@ -592,7 +592,10 @@ impl Loader {
                         let checksum = session_storage.load_checksum(module_id)?;
                         let locked_module_cache = self.module_cache.read();
                         match locked_module_cache.get(&checksum) {
-                            Some(m) => Some(m.compiled_module().immediate_dependencies()),
+                            Some(m) => {
+                                self.module_cache_hits.write().record_hit(&checksum);
+                                Some(m.compiled_module().immediate_dependencies())
+                            },
                             None => {
                                 // explicit drop
                                 drop(locked_module_cache);
@@ -621,7 +624,10 @@ impl Loader {
                             let checksum = session_storage.load_checksum(module_id)?;
                             let locked_module_cache = self.module_cache.read();
                             match locked_module_cache.get(&checksum) {
-                                Some(m) => Some(m.compiled_module().immediate_friends()),
+                                Some(m) => {
+                                    self.module_cache_hits.write().record_hit(&checksum);
+                                    Some(m.compiled_module().immediate_friends())
+                                },
                                 None => {
                                     // explicit drop
                                     drop(locked_module_cache);
@@ -956,7 +962,6 @@ impl Loader {
                 let loaded = match locked_cache.get(&checksum) {
                     Some(cached) => {
                         self.module_cache_hits.write().record_hit(&checksum);
-
                         cached
                     }
                     None => {


### PR DESCRIPTION
`load_and_verify_dependencies` do not guarantee all modules are loaded because it will return cached module when it exists in cache.