### PR TITLE
fix: typos in description lines of the code

### DIFF
--- a/move-model/src/constant_folder.rs
+++ b/move-model/src/constant_folder.rs
@@ -237,7 +237,7 @@ impl<'env> ConstantFolder<'env> {
             .unwrap_or_else(|| BigInt::from(256))
     }
 
-    /// Try constant folding of a non-tuple binary operation `oper` applied to arguements `arg0` and
+    /// Try constant folding of a non-tuple binary operation `oper` applied to arguments `arg0` and
     /// `arg1`, returning `Some(exp)` where `exp` is a ExpData::Value(id, ..)` expression if
     /// constant folding is possible.  Operation result type may be obtained from `id`.
     ///

--- a/tools/move-bytecode-utils/src/dependency_graph.rs
+++ b/tools/move-bytecode-utils/src/dependency_graph.rs
@@ -19,7 +19,7 @@ struct ModuleIndex(usize);
 
 impl<'a> DependencyGraph<'a> {
     /// Construct a dependency graph from a set of `modules`.
-    /// Panics if `modules` contains duplicates or is not closed under the depedency relation
+    /// Panics if `modules` contains duplicates or is not closed under the dependency relation
     pub fn new(module_iter: impl IntoIterator<Item = &'a CompiledModule>) -> Self {
         let mut modules = vec![];
         let mut reverse_modules = BTreeMap::new();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Corrected typographical errors in documentation comments for the `fold_binary_exp` method and the `new` method, enhancing clarity and accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->